### PR TITLE
Fixes repo link for crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wpactrl"
 description = "wpa_supplicant control interface library"
 license-file = "LICENSE"
-repository = "https://github.com/sauyon/wpa-ctrl-rust"
+repository = "https://github.com/sauyon/wpa-ctrl-rs"
 version = "0.2.1"
 authors = [ "Sauyon Lee <s@uyon.co>" ]
 


### PR DESCRIPTION
The current link just 404s making it slightly harder to find the repo from a search on crates.io. 