### PR TITLE
Replace failure with a custom error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,5 @@ version = "0.3.1"
 authors = [ "Sauyon Lee <s@uyon.co>", "Steven Pease <peasteven@gmail.com>" ]
 
 [dependencies]
-failure = "0.1.1"
 nix = "0.10.0"
 log = "0.4.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,9 +26,9 @@ impl std::error::Error for WpaError {
         match *self {
             WpaError::Attach => None,
             WpaError::Detach => None,
-            WpaError::Io(_) => None,
-            WpaError::Nix(_) => None,
-            WpaError::Utf8ToStr(_) => None,
+            WpaError::Io(ref source) => Some(source),
+            WpaError::Nix(ref source) => Some(source),
+            WpaError::Utf8ToStr(ref source) => Some(source),
         }
     }
 }
@@ -48,7 +48,9 @@ impl std::fmt::Display for WpaError {
             WpaError::Nix(ref err) => {
                 write!(f, "Failed to execute the specified command: {}", err)
             }
-            WpaError::Utf8ToStr(ref err) => err.fmt(f),
+            WpaError::Utf8ToStr(ref err) => {
+                write!(f, "Failed to parse UTF8 to string: {}", err)
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,72 @@
+#![deny(missing_docs)]
+
+use std::{io, str};
+
+/// Error type used for some library functions
+#[derive(Debug)]
+pub enum WpaError {
+    /// Represents all cases of `std::io::Error`.
+    Io(io::Error),
+
+    /// Represents all cases of `nix::Error`.
+    Nix(nix::Error),
+
+    /// Represents a failure to interpret a sequence of u8 as a string slice.
+    Utf8ToStr(str::Utf8Error),
+
+    /// Represents a failed `ATTACH` request to wpasupplicant.
+    Attach,
+
+    /// Represents a failed `DETACH` request to wpasupplicant.
+    Detach,
+}
+
+impl std::error::Error for WpaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            WpaError::Attach => None,
+            WpaError::Detach => None,
+            WpaError::Io(_) => None,
+            WpaError::Nix(_) => None,
+            WpaError::Utf8ToStr(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WpaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            WpaError::Attach => {
+                write!(f, "Failed to attach to wpasupplicant")
+            }
+            WpaError::Detach => {
+                write!(f, "Failed to detach from wpasupplicant")
+            }
+            WpaError::Io(ref err) => {
+                write!(f, "Failed to execute the specified command: {}", err)
+            }
+            WpaError::Nix(ref err) => {
+                write!(f, "Failed to execute the specified command: {}", err)
+            }
+            WpaError::Utf8ToStr(ref err) => err.fmt(f),
+        }
+    }
+}
+
+impl From<std::io::Error> for WpaError {
+    fn from(err: std::io::Error) -> WpaError {
+        WpaError::Io(err)
+    }
+}
+
+impl From<nix::Error> for WpaError {
+    fn from(err: nix::Error) -> WpaError {
+        WpaError::Nix(err)
+    }
+}
+
+impl From<str::Utf8Error> for WpaError {
+    fn from(err: str::Utf8Error) -> WpaError {
+        WpaError::Utf8ToStr(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,14 +14,14 @@
 //! The library currently only supports UNIX sockets, but additional
 //! connection methods (eg UDP or pipes) may be added in the future.
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate log;
 extern crate nix;
 
+mod error;
 mod wpactrl;
 pub use wpactrl::{WpaCtrl, WpaCtrlAttached, WpaCtrlBuilder};
 
-use failure::Error;
+use crate::error::WpaError;
+
 /// Result type used for the library
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = ::std::result::Result<T, WpaError>;


### PR DESCRIPTION
Thank you for this crate. I have been using it in a JSON-RPC networking server for a couple of years.

This PR replaces the `failure` dependency with a custom error type and implementation for `WpaError` (moved from `src/wpactrl.rs` to `src/error.rs`).

With the custom error type, total build dependencies are reduced from 46 to 17 and the release build compilation time drops from 8.94 seconds to 3.27 seconds on my local machine. I think this offers a great improvement for a low-level library such as wpa-ctrl-rs.

The other changes in the diff are a result of `cargo fmt`.

I welcome your feedback. Thanks again.